### PR TITLE
fix: improve SYNC_PAGES env var error messages and empty-string handling

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -141,19 +141,24 @@ def _parse_pages(pages_arg: str | None) -> set[str]:
     """Parse --pages argument into a set of page names.
 
     Falls back to SYNC_PAGES env var if --pages is not provided.
+    An empty or whitespace-only SYNC_PAGES value is treated as unset (use defaults).
     """
-    if pages_arg is None:
+    from_env = pages_arg is None
+    if from_env:
         pages_arg = os.getenv("SYNC_PAGES")
     if pages_arg is None:
         return DEFAULT_PAGES.copy()
     requested = {p.strip().lower() for p in pages_arg.split(",") if p.strip()}
+    if not requested:
+        if from_env:
+            return DEFAULT_PAGES.copy()
+        raise argparse.ArgumentTypeError("--pages requires at least one page")
     invalid = requested - ALL_PAGES
     if invalid:
+        source = "SYNC_PAGES" if from_env else "--pages"
         raise argparse.ArgumentTypeError(
-            f"Unknown page(s): {', '.join(sorted(invalid))}. Valid pages: {', '.join(sorted(ALL_PAGES))}"
+            f"Unknown page(s) in {source}: {', '.join(sorted(invalid))}. Valid pages: {', '.join(sorted(ALL_PAGES))}"
         )
-    if not requested:
-        raise argparse.ArgumentTypeError("--pages requires at least one page")
     return requested
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -76,7 +76,7 @@ def test_parse_pages_with_spaces():
 
 
 def test_parse_pages_invalid():
-    with pytest.raises(argparse.ArgumentTypeError, match="Unknown page"):
+    with pytest.raises(argparse.ArgumentTypeError, match="Unknown page\\(s\\) in --pages"):
         _parse_pages("daily,banana")
 
 
@@ -93,6 +93,31 @@ def test_parse_pages_env_var(monkeypatch):
 def test_parse_pages_cli_overrides_env(monkeypatch):
     monkeypatch.setenv("SYNC_PAGES", "daily")
     assert _parse_pages("sleep,activities") == {"sleep", "activities"}
+
+
+def test_parse_pages_env_var_empty_string_falls_back_to_defaults(monkeypatch):
+    """SYNC_PAGES='' should silently fall back to defaults, not raise an error."""
+    monkeypatch.setenv("SYNC_PAGES", "")
+    assert _parse_pages(None) == DEFAULT_PAGES
+
+
+def test_parse_pages_env_var_whitespace_only_falls_back_to_defaults(monkeypatch):
+    """SYNC_PAGES with only whitespace/commas falls back to defaults."""
+    monkeypatch.setenv("SYNC_PAGES", "  ,  ")
+    assert _parse_pages(None) == DEFAULT_PAGES
+
+
+def test_parse_pages_env_var_invalid_mentions_sync_pages(monkeypatch):
+    """Error for unknown page from SYNC_PAGES should mention SYNC_PAGES, not --pages."""
+    monkeypatch.setenv("SYNC_PAGES", "daily,banana")
+    with pytest.raises(argparse.ArgumentTypeError, match="SYNC_PAGES"):
+        _parse_pages(None)
+
+
+def test_parse_pages_cli_invalid_mentions_pages_flag():
+    """Error for unknown page from --pages should mention --pages."""
+    with pytest.raises(argparse.ArgumentTypeError, match="--pages"):
+        _parse_pages("daily,banana")
 
 
 # --- _parse_idle_timeout tests ---


### PR DESCRIPTION
Addresses #1

## Summary
- Error messages in `_parse_pages` now name the source correctly: `SYNC_PAGES` (env var) or `--pages` (CLI flag). Previously both said `--pages`, making config.env mistakes hard to diagnose.
- `SYNC_PAGES=""` or `SYNC_PAGES="  "` now silently falls back to defaults instead of raising a confusing error referencing `--pages`.
- Added 4 new tests covering these behaviours.

## Test plan
- [x] All tests pass (106 passed)
- [x] Lint clean (ruff check + ruff format)
- [x] No security issues (bandit)