### PR TITLE
fix: parse multipart/mixed GraphQL responses from graphql-gateway

### DIFF
--- a/src/scraper.py
+++ b/src/scraper.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import random
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Callable
@@ -112,6 +113,46 @@ class SyncResult:
         return len(self.pages_failed) == 0 and len(self.pages_loaded) > 0
 
 
+def _extract_multipart_boundary(content_type: str) -> str | None:
+    """Extract the boundary parameter from a multipart Content-Type header value."""
+    match = re.search(r"boundary=([^\s;]+)", content_type, re.IGNORECASE)
+    return match.group(1).strip('"') if match else None
+
+
+def _parse_multipart_graphql_body(raw: bytes, boundary: str) -> dict:
+    """Merge JSON data from all parts of a multipart/mixed GraphQL response.
+
+    Handles both top-level ``data`` fields (initial chunk) and ``incremental``
+    chunks produced by ``@defer`` / ``@stream`` queries.
+    """
+    merged: dict = {}
+    sep = ("--" + boundary).encode()
+    for chunk in raw.split(sep):
+        # Each MIME part: headers + blank line + body
+        for divider in (b"\r\n\r\n", b"\n\n"):
+            if divider not in chunk:
+                continue
+            part_body = chunk.split(divider, 1)[1].strip()
+            if part_body.startswith(b"--"):  # boundary epilogue
+                break
+            try:
+                payload = json.loads(part_body)
+            except Exception:
+                break
+            if not isinstance(payload, dict):
+                break
+            top = payload.get("data")
+            if isinstance(top, dict):
+                merged.update(top)
+            for inc in payload.get("incremental") or []:
+                if isinstance(inc, dict):
+                    inc_data = inc.get("data")
+                    if isinstance(inc_data, dict):
+                        merged.update(inc_data)
+            break
+    return merged
+
+
 def _make_response_handler(captured: dict[str, dict | list]) -> Callable:
     """Create a response handler that captures matched API responses."""
 
@@ -130,14 +171,23 @@ def _make_response_handler(captured: dict[str, dict | list]) -> Callable:
                 break
 
         if "graphql-gateway/graphql" in url:
+            gql_data: dict | None = None
             try:
-                data = response.json()
-                gql_data = data.get("data", {})
-                for gql_key in gql_data:
-                    captured[f"graphql/{gql_key}"] = gql_data[gql_key]
-                    logger.debug("Captured GraphQL: %s", gql_key)
+                content_type = (response.headers.get("content-type") or "").lower()
+                if "multipart/mixed" in content_type:
+                    boundary = _extract_multipart_boundary(content_type)
+                    if boundary:
+                        gql_data = _parse_multipart_graphql_body(response.body(), boundary)
+                else:
+                    payload = response.json()
+                    if isinstance(payload, dict):
+                        gql_data = payload.get("data")
             except Exception:
-                logger.debug("Non-JSON response for graphql-gateway on %s, skipping", url)
+                logger.debug("Failed to parse GraphQL response for %s", url)
+            if gql_data:
+                for gql_key, gql_val in gql_data.items():
+                    captured[f"graphql/{gql_key}"] = gql_val
+                    logger.debug("Captured GraphQL: %s", gql_key)
 
     return handler
 

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,8 +1,17 @@
 """Tests for scraper crash-recovery, response-handler reattachment, and CF handling."""
 
+import json
 from unittest.mock import MagicMock, call, patch
 
-from src.scraper import SyncResult, _handle_cloudflare_challenge, _navigate, _recover_page
+from src.scraper import (
+    SyncResult,
+    _extract_multipart_boundary,
+    _handle_cloudflare_challenge,
+    _make_response_handler,
+    _navigate,
+    _parse_multipart_graphql_body,
+    _recover_page,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -341,3 +350,139 @@ def test_navigate_calls_cf_handler_after_goto():
         _navigate(page, "https://example.com", result, "daily summary (2026-03-29)")
 
     mock_cf.assert_called_once_with(page)
+
+
+# ---------------------------------------------------------------------------
+# _extract_multipart_boundary
+# ---------------------------------------------------------------------------
+
+
+def test_extract_boundary_unquoted():
+    ct = "multipart/mixed; boundary=graphql"
+    assert _extract_multipart_boundary(ct) == "graphql"
+
+
+def test_extract_boundary_quoted():
+    ct = 'multipart/mixed; boundary="-"'
+    assert _extract_multipart_boundary(ct) == "-"
+
+
+def test_extract_boundary_missing():
+    assert _extract_multipart_boundary("application/json") is None
+
+
+def test_extract_boundary_case_insensitive():
+    ct = "multipart/mixed; Boundary=abc123"
+    assert _extract_multipart_boundary(ct) == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# _parse_multipart_graphql_body
+# ---------------------------------------------------------------------------
+
+
+def _make_multipart(boundary: str, parts: list[dict]) -> bytes:
+    """Build a minimal multipart/mixed body from a list of JSON payloads."""
+    lines = []
+    sep = f"--{boundary}"
+    for payload in parts:
+        lines.append(sep)
+        lines.append("Content-Type: application/json")
+        lines.append("")
+        lines.append(json.dumps(payload))
+    lines.append(f"{sep}--")
+    return "\r\n".join(lines).encode()
+
+
+def test_parse_multipart_single_part():
+    body = _make_multipart("graphql", [{"data": {"trainingStatus": {"status": "productive"}}}])
+    result = _parse_multipart_graphql_body(body, "graphql")
+    assert result == {"trainingStatus": {"status": "productive"}}
+
+
+def test_parse_multipart_merges_incremental():
+    parts = [
+        {"data": {"trainingStatus": {"status": "productive"}}, "hasNext": True},
+        {"incremental": [{"data": {"fitnessAge": 30}, "path": []}], "hasNext": False},
+    ]
+    body = _make_multipart("-", parts)
+    result = _parse_multipart_graphql_body(body, "-")
+    assert result["trainingStatus"] == {"status": "productive"}
+    assert result["fitnessAge"] == 30
+
+
+def test_parse_multipart_empty_body():
+    result = _parse_multipart_graphql_body(b"", "graphql")
+    assert result == {}
+
+
+def test_parse_multipart_ignores_invalid_json_parts():
+    boundary = "graphql"
+    sep = f"--{boundary}"
+    body = f"{sep}\r\nContent-Type: application/json\r\n\r\nnot-json\r\n{sep}--".encode()
+    result = _parse_multipart_graphql_body(body, boundary)
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _make_response_handler — GraphQL branch
+# ---------------------------------------------------------------------------
+
+
+def _make_gql_response(content_type: str, body: bytes | None = None, json_data: dict | None = None) -> MagicMock:
+    """Build a mock Playwright Response for graphql-gateway calls."""
+    resp = MagicMock()
+    resp.status = 200
+    resp.url = "https://connect.garmin.com/gc-api/graphql-gateway/graphql"
+    resp.headers = {"content-type": content_type}
+    if body is not None:
+        resp.body.return_value = body
+    if json_data is not None:
+        resp.json.return_value = json_data
+    else:
+        resp.json.side_effect = ValueError("not JSON")
+    return resp
+
+
+def test_handler_captures_standard_json_graphql():
+    captured: dict = {}
+    handler = _make_response_handler(captured)
+    resp = _make_gql_response(
+        "application/json",
+        json_data={"data": {"trainingStatus": {"status": "productive"}}},
+    )
+    handler(resp)
+    assert "graphql/trainingStatus" in captured
+    assert captured["graphql/trainingStatus"] == {"status": "productive"}
+
+
+def test_handler_captures_multipart_graphql():
+    parts = [
+        {"data": {"trainingStatus": {"status": "productive"}}, "hasNext": True},
+        {"incremental": [{"data": {"fitnessAge": 28}, "path": []}], "hasNext": False},
+    ]
+    body = _make_multipart("graphql", parts)
+    captured: dict = {}
+    handler = _make_response_handler(captured)
+    resp = _make_gql_response("multipart/mixed; boundary=graphql", body=body)
+    handler(resp)
+    assert captured.get("graphql/trainingStatus") == {"status": "productive"}
+    assert captured.get("graphql/fitnessAge") == 28
+
+
+def test_handler_skips_graphql_when_no_boundary():
+    captured: dict = {}
+    handler = _make_response_handler(captured)
+    resp = _make_gql_response("multipart/mixed")  # no boundary param
+    resp.body.return_value = b""
+    handler(resp)
+    assert not any(k.startswith("graphql/") for k in captured)
+
+
+def test_handler_skips_graphql_on_exception():
+    captured: dict = {}
+    handler = _make_response_handler(captured)
+    resp = _make_gql_response("multipart/mixed; boundary=graphql")
+    resp.body.side_effect = RuntimeError("network error")
+    handler(resp)  # must not raise
+    assert not any(k.startswith("graphql/") for k in captured)


### PR DESCRIPTION
Addresses #3

## Summary
- Garmin Connect's GraphQL gateway returns `multipart/mixed` responses for queries using `@defer`/`@stream` (incremental delivery). These previously failed `response.json()` and were silently skipped, causing training-status, fitness metrics, and other GraphQL-served data to be absent from syncs.
- Add `_extract_multipart_boundary()` to parse the MIME boundary from the `Content-Type` header.
- Add `_parse_multipart_graphql_body()` to split the multipart body, parse each JSON part, and merge top-level `data` fields and any `incremental` chunks produced by `@defer`.
- Update `_make_response_handler` to detect `multipart/mixed` and route to the new parser; standard `application/json` responses continue to use `response.json()` as before.

## Test plan
- [x] All tests pass (114 passed)
- [x] Lint clean (`ruff check`)
- [x] Properly formatted (`ruff format --check`)
- [x] No security issues (`bandit`)
- [x] `test_extract_boundary_*` — boundary extraction with/without quotes, missing param
- [x] `test_parse_multipart_*` — single part, incremental merge, empty body, invalid JSON
- [x] `test_handler_captures_*` — standard JSON and multipart paths through the response handler